### PR TITLE
Rename parameter `async` in usages of clingo.Control.solve into `async_`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ and run `asprin` with `python dir/asprin/asprin/asprin.py`.
 
 System tests may be run with ```asprin --test``` and ```asprin --test --all```.
 
-`asprin` has been tested with `Python 2.7.13` and `3.5.3`, using `clingo 5.3.0`.
+`asprin` has been tested with `Python 2.7.13` and `3.5.3`, using `clingo 5.4.0`.
 
 ```asprin``` uses the `ply` library, version `3.11`,
 which is bundled in [asprin/src/spec_parser/ply](https://github.com/potassco/asprin/tree/master/asprin/src/spec_parser/ply),

--- a/asprin/src/utils/clingo_signal_handler.py
+++ b/asprin/src/utils/clingo_signal_handler.py
@@ -127,7 +127,7 @@ class ClingoSignalHandler:
     def do_solve(self, control, *args, **kwargs):
         with self.condition:
             with control.solve(
-                async=True, on_finish=self.stop, *args, **kwargs
+                async_=True, on_finish=self.stop, *args, **kwargs
             ) as handle:
                 # In Python 2, Condition.wait() isn't interruptible when called without a timeout.
                 # In Python 3, infinite timeouts lead to overflow errors.


### PR DESCRIPTION
Python 3.7 introduced `async` as a new keyword. That broke the Python API of Clingo since clingo.Control.solve used to have a parameter which was also called `async`. That problem was resolved with the release of Clingo 5.4.0 which renamed the parameter `async` into `async_`. This commit renames the parameter `async` into `async_` throughout all usages of clingo.Control.solve in asprin.

This change should (hopefully) make asprin compatible with Clingo 5.4.0 and Python 3.7.