### PR TITLE
Fix incompatibilities with Clingo 5.5+ API

### DIFF
--- a/asprin/src/main/main.py
+++ b/asprin/src/main/main.py
@@ -223,7 +223,7 @@ License: The MIT License <https://opensource.org/licenses/MIT>"""
             for i in alist:
                 old, sep, new = i.partition("=")
                 self.__update_underscores(new)
-                if new is "":
+                if new == "":
                     raise Exception(
                         "no definition for constant {}".format(old)
                     )

--- a/asprin/src/program_parser/basic.py
+++ b/asprin/src/program_parser/basic.py
@@ -22,8 +22,8 @@
 # -*- coding: utf-8 -*-
 
 import clingo.ast
+from clingo.ast import ASTType
 from ..utils import utils
-from ..program_parser import transitive_closure
 from ..program_parser import visitor
 
 
@@ -152,12 +152,12 @@ class BasicProgramVisitor(visitor.Visitor):
     # Elements
     #
 
-    def visit_SymbolicAtom(self, atom):
-        if str(atom.term.type) == "Function":
-            if atom.term.name == HOLDSP and len(atom.term.arguments)==1:
+    def visit_SymbolicAtom(self, atom: clingo.ast.AST):
+        if atom.ast_type == ASTType.SymbolicAtom:
+            if atom.symbol.name == HOLDSP and len(atom.symbol.arguments) == 1:
                 string = ERROR_HOLDSP.format(self.type, str(atom))
                 self.helper.raise_exception(string)
-            self.__term_transformer.transform_function(atom.term)
+            self.__term_transformer.transform_function(atom.symbol)
 
     # csp literals are not accepted
     def visit_CSPLiteral(self,csp):

--- a/asprin/src/program_parser/program_parser.py
+++ b/asprin/src/program_parser/program_parser.py
@@ -23,6 +23,7 @@
 
 from __future__ import print_function
 import clingo
+import clingo.ast
 import sys
 from ..utils import utils
 from ..utils import printer
@@ -394,7 +395,7 @@ class Parser:
             for type_, program in self.__programs[name].items():
                 if type_ in types:
                     s = "#program " + name + ".\n" + program.get_string()
-                    clingo.parse_program(s, lambda x: visitor.visit(x))
+                    clingo.ast.parse_string(s, lambda x: visitor.visit(x))
             ret = visitor.finish()
             # error if unsat preference program not stratified and not meta
             if ret and self.__options['meta'] == META_OPEN and \
@@ -424,13 +425,13 @@ class Parser:
         # option --print-programs
         if self.__options['print-programs']:
             self.print_basic_programs(types)
-            with self.__control.builder() as _builder:
+            with clingo.ast.ProgramBuilder(self.__control) as _builder:
                 builder = BuilderProxy(_builder)
                 self.add_programs(types, builder)
             raise utils.SilentException() # end
 
         # translate and add the rest of the programs
-        with self.__control.builder() as builder:
+        with clingo.ast.ProgramBuilder(self.__control) as builder:
             observer_builder = None
             if self.__observer:
                 observer_builder = ObserverBuilderProxy(builder, self.__observer)

--- a/asprin/src/program_parser/visitor.py
+++ b/asprin/src/program_parser/visitor.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # -*- coding: utf-8 -*-
+from typing import List, Sequence
 
 import clingo
 import clingo.ast
@@ -93,16 +94,15 @@ class Helper:
     def underscore(self,x):
         return self.underscores + x
 
-    def get_ems(self, loc, ems):
+    def get_ems(self, loc: clingo.ast.Location, ems: str) -> List[clingo.ast.AST]:
         if   ems == M1:
-            return [clingo.ast.Symbol(loc, self.simple_m1)]
+            return [clingo.ast.SymbolicTerm(loc, self.simple_m1)]
         elif ems == M2:
-            return [clingo.ast.Symbol(loc, self.simple_m2)]
+            return [clingo.ast.SymbolicTerm(loc, self.simple_m2)]
         elif ems == M1_M2:
-            return [clingo.ast.Symbol(loc, self.m1),
-                    clingo.ast.Symbol(loc, self.m2)]
+            return [clingo.ast.SymbolicTerm(loc, self.m1), clingo.ast.SymbolicTerm(loc, self.m2)]
         elif ems == ZERO:
-            return [clingo.ast.Symbol(loc, self.zero)]
+            return [clingo.ast.SymbolicTerm(loc, self.zero)]
         else:
             return []
 
@@ -129,14 +129,12 @@ class Visitor:
 
     def visit(self, x, *args, **kwargs):
         if isinstance(x, clingo.ast.AST):
-            attr = "visit_" + str(x.type)
+            attr = "visit_" + str(x.ast_type.name)
             if hasattr(self, attr):
-                setattr(x, "in_"+attr, True)  # added
                 getattr(self, attr)(x, *args, **kwargs)
-                setattr(x, "in_"+attr, False) # added
             else:
                 self.visit_children(x, *args, **kwargs)
-        elif isinstance(x, list):
+        elif isinstance(x, Sequence):
             for y in x:
                 self.visit(y, *args, **kwargs)
         elif x is None:

--- a/asprin/src/solver/metasp/metasp.py
+++ b/asprin/src/solver/metasp/metasp.py
@@ -27,6 +27,8 @@
 #
 
 import clingo
+import clingo.ast
+from clingo.ast import ASTType
 import re
 from . import metasp_programs
 from . import reify
@@ -119,36 +121,37 @@ ASPRIN_LIBRARY_PY = """
 #script(python)
 
 import math
+from clingo.symbol import Number
 
-def exp2(x):
-    return int(math.pow(2,x.number))
+def exp2(self, x: clingo.Symbol) -> clingo.Symbol:
+    return clingo.Number(int(math.pow(2, x.number)))
 
-def get(atuple, index):
+def get(self, atuple: clingo.Symbol, index: clingo.Symbol) -> clingo.Symbol:
     try:
         return atuple.arguments[index.number]
     except:
         return atuple
 
-def get_mode():
-    return 'normal'
+def get_mode(self) -> clingo.Symbol:
+    return clingo.String('normal')
 
 sequences = {}
-def get_sequence(name, elem):
+def get_sequence(self, name: clingo.Symbol, elem) -> clingo.Symbol:
     string = str(name)
     if string in sequences:
         sequences[string] += 1
     else:
         sequences[string]  = 1
-    return sequences[string]
+    return clingo.Number(sequences[string])
 
-def length(atuple):
+def length(self, atuple: clingo.Symbol) -> clingo.Symbol:
     try:
-        return len(atuple.arguments)
+        return clingo.Number(len(atuple.arguments))
     except:
-        return 1 
+        return clingo.Number(1)
 
-def log2up(x):
-    return int(math.ceil(math.log(x.number,2)))
+def log2up(self, x: clingo.Symbol) -> clingo.Symbol:
+    return clingo.Number(int(math.ceil(math.log(x.number, 2))))
 
 #end.
 """
@@ -284,10 +287,10 @@ class AbstractMetasp:
     # get_pref() (used by MetaspPython and MetaspBinary)
     #
 
-    def statement_to_str(self, statement):
-        if str(statement.type) == "Definition": # to avoid printing [default]
+    def statement_to_str(self, statement: clingo.ast.AST):
+        if statement.ast_type == ASTType.Definition: # to avoid printing [default]
             return "#const {}={}.".format(statement.name, statement.value)
-        elif str(statement.type) == "Program":
+        elif statement.ast_type == ASTType.Program:
             return "" # IMPORTANT: program statements are skipped
         return str(statement)
 

--- a/asprin/src/utils/utils.py
+++ b/asprin/src/utils/utils.py
@@ -24,8 +24,7 @@
 import os
 import tempfile
 import re
-import sys
-import clingo
+import clingo.ast
 
 #
 # defines


### PR DESCRIPTION
Clingo 5.5 introduced several breaking changes that made asprin incompatible with newer Clingo versions.
See for example issues #5 or #9.

The changes in this PR should make asprin compatible with Clingo 5.5+ again. They were tested using `asprin --test --all` with Clingo 5.5.2 (latest 5.5 release) and 5.6.1 (latest release).